### PR TITLE
fix: link Openlake logo text to homepage instead of error page

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -21,7 +21,7 @@ const Navbar = () => {
         <a href="/" className="navbar__logo">
           <img src={logonav} alt="logonav" />
         </a>
-        <a href="/error" >
+        <a href="/" >
           <span className="navbar__company-name">OpenLake</span>
         </a>
 


### PR DESCRIPTION
#Description:
Fixed link Openlake logo text to homepage instead of error page.


Closes #6