### PR TITLE
[SPRINT-M26] fix: bottom Events button navigation

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -42,7 +42,7 @@ const Footer = () => {
                     Community
                 </a>
 
-                <a href="/events" className="section-link">
+                <a href="/programs" className="section-link">
                     Events
                 </a>
 


### PR DESCRIPTION
Solves:#36

@amaydixit11
 
This PR fixes the broken bottom Events button navigation in the footer. The button was incorrectly pointing to /events, which caused it not to work as intended. It has now been updated to correctly navigate to the Programs page.

- Changes Made

1. Updated footer.jsx: changed href="/events" → href="/programs".
2. Verified consistency with the top navigation button.

- Reason for Change

1. Ensures both top and bottom navigation buttons behave consistently.
2. Improves user experience by allowing footer navigation to correctly lead to the Programs page.
3. Prevents confusion for users who try to access Events/Programs from the footer.

- Before: Bottom button did not navigate anywhere.
- After: Bottom button now redirects properly to /programs.