### PR TITLE
Add openlake discord server link for mobile

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -497,7 +497,7 @@ export function Navbar({ invertColors = false }: { invertColors?: boolean }) {
               );
             })}
             <a
-              href="https://slack.hackclub.com"
+              href="https://discord.gg/A2J9z92qzd"
               className="dark-btn mobile-nav-item"
               onClick={closeMenu}
               style={{

--- a/components/landing/joining.tsx
+++ b/components/landing/joining.tsx
@@ -638,7 +638,7 @@ export function JoiningSection() {
                 people we really wanted to talk to, so we just invited them.
               </p>
               {/* CTA Button */}
-              <CardCta href="https://slack.hackclub.com/">Join the Slack</CardCta>
+              <CardCta href="https://discord.gg/A2J9z92qzd">Join the discord server</CardCta>
             </div>
 
             {/* Slack stats badges — overflow off right edge, hidden on mobile */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated community links to direct users to the Hack Club Discord server instead of Slack.
  * Applied the updated destination to both the mobile navigation and joining card call-to-action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->